### PR TITLE
fix: Add missing claude_config.sh library and unify config file paths

### DIFF
--- a/scripts/lib/claude_config.sh
+++ b/scripts/lib/claude_config.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# claude_config.sh - Shared utilities for Claude Code MCP configuration
+#
+# Functions for detecting and managing Claude Code configuration files
+
+# Detect Claude Code MCP config location
+# Returns the path to the appropriate config file based on platform
+detect_claude_mcp_config() {
+    local claude_config=""
+
+    # Try new location first (Claude Code 1.0+)
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # macOS
+        claude_config="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+    elif [[ "$(uname)" == "Linux" ]]; then
+        # Linux
+        claude_config="$HOME/.config/Claude/claude_desktop_config.json"
+    fi
+
+    # If new location doesn't exist, try legacy location
+    if [[ ! -f "$claude_config" ]]; then
+        # Legacy location
+        if [[ -d "$HOME/.claude" ]]; then
+            claude_config="$HOME/.claude/config.json"
+        else
+            # Default to new location for creation
+            if [[ "$(uname)" == "Darwin" ]]; then
+                claude_config="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+            else
+                claude_config="$HOME/.config/Claude/claude_desktop_config.json"
+            fi
+        fi
+    fi
+
+    echo "$claude_config"
+}
+
+# Initialize Claude Code MCP config if it doesn't exist
+# Args:
+#   $1 - Path to config file
+init_claude_mcp_config() {
+    local config_file="$1"
+    local config_dir=$(dirname "$config_file")
+
+    # Create directory if needed
+    if [[ ! -d "$config_dir" ]]; then
+        mkdir -p "$config_dir"
+    fi
+
+    # Create minimal config if file doesn't exist
+    if [[ ! -f "$config_file" ]]; then
+        cat > "$config_file" << 'EOF'
+{
+  "mcpServers": {}
+}
+EOF
+        chmod 600 "$config_file"
+    fi
+}
+
+# Check if config migration from old location is needed
+# Offers to migrate config from ~/.claude/config.json to new location
+check_config_migration() {
+    local old_config="$HOME/.claude/config.json"
+    local new_config=$(detect_claude_mcp_config)
+
+    # Skip if old config doesn't exist or new config already exists
+    if [[ ! -f "$old_config" ]] || [[ -f "$new_config" ]]; then
+        return 0
+    fi
+
+    # Skip if they're the same file
+    if [[ "$old_config" == "$new_config" ]]; then
+        return 0
+    fi
+
+    echo ""
+    echo -e "${YELLOW}[MIGRATION]${NC} Found legacy Claude config at: $old_config"
+    echo -e "${YELLOW}[MIGRATION]${NC} New location is: $new_config"
+    echo ""
+
+    read -p "Would you like to migrate the config? [Y/n] " -n 1 -r
+    echo
+
+    if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+        # Create directory for new config
+        local new_dir=$(dirname "$new_config")
+        mkdir -p "$new_dir"
+
+        # Copy config
+        cp "$old_config" "$new_config"
+        chmod 600 "$new_config"
+
+        echo -e "${GREEN}[OK]${NC} Config migrated to: $new_config"
+        echo -e "${BLUE}[INFO]${NC} Old config preserved at: $old_config"
+        echo ""
+    fi
+}

--- a/scripts/ninja-cli-mcp.service
+++ b/scripts/ninja-cli-mcp.service
@@ -9,6 +9,7 @@ User=%i
 Group=%i
 WorkingDirectory=%h/Project/software/ninja-cli-mcp
 Environment="PATH=%h/.local/bin:%h/.nvm/versions/node/v25.0.0/bin:/usr/local/bin:/usr/bin:/bin"
+EnvironmentFile=-%h/.ninja-mcp.env
 EnvironmentFile=-%h/.ninja-cli-mcp.env
 ExecStart=/usr/bin/env bash %h/Project/software/ninja-cli-mcp/scripts/run_server.sh
 Restart=on-failure

--- a/scripts/restart_mcp.sh
+++ b/scripts/restart_mcp.sh
@@ -53,17 +53,24 @@ echo ""
 
 # Verify configuration
 info "Verifying configuration..."
-if [[ -f ~/.ninja-cli-mcp.env ]]; then
-    source ~/.ninja-cli-mcp.env
+if [[ -f ~/.ninja-mcp.env ]]; then
+    source ~/.ninja-mcp.env
     success "Configuration loaded"
     echo "   NINJA_CODE_BIN: $NINJA_CODE_BIN"
     echo "   NINJA_MODEL: ${NINJA_MODEL:0:40}..."
     echo "   API Key: ${OPENROUTER_API_KEY:0:10}...${OPENROUTER_API_KEY: -4}"
+elif [[ -f ~/.ninja-cli-mcp.env ]]; then
+    # Legacy config file name - still supported
+    source ~/.ninja-cli-mcp.env
+    success "Configuration loaded (legacy file)"
+    echo "   NINJA_CODE_BIN: $NINJA_CODE_BIN"
+    echo "   NINJA_MODEL: ${NINJA_MODEL:0:40}..."
+    echo "   API Key: ${OPENROUTER_API_KEY:0:10}...${OPENROUTER_API_KEY: -4}"
 else
-    error "Configuration file not found: ~/.ninja-cli-mcp.env"
+    error "Configuration file not found: ~/.ninja-mcp.env"
     echo ""
     echo "Create it with:"
-    echo "  bash scripts/install_coding_cli.sh aider"
+    echo "  bash scripts/install_interactive.sh"
     exit 1
 fi
 echo ""
@@ -134,7 +141,7 @@ echo "     bash scripts/test_aider_integration.sh"
 echo ""
 echo "Configuration:"
 echo "  • Server location: $PROJECT_ROOT"
-echo "  • Config file: ~/.ninja-cli-mcp.env"
+echo "  • Config file: ~/.ninja-mcp.env"
 echo "  • MCP config: ~/.copilot/mcp-config.json"
 echo "  • Coding CLI: $NINJA_CODE_BIN (Aider)"
 echo "  • Model: ${NINJA_MODEL:0:40}..."

--- a/scripts/run_daemon.sh
+++ b/scripts/run_daemon.sh
@@ -11,7 +11,10 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 # Load environment
-if [[ -f "$HOME/.ninja-cli-mcp.env" ]]; then
+if [[ -f "$HOME/.ninja-mcp.env" ]]; then
+    source "$HOME/.ninja-mcp.env"
+elif [[ -f "$HOME/.ninja-cli-mcp.env" ]]; then
+    # Legacy config file name - still supported
     source "$HOME/.ninja-cli-mcp.env"
 fi
 

--- a/scripts/run_server.sh
+++ b/scripts/run_server.sh
@@ -24,7 +24,10 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 # Load environment config if it exists
-if [[ -f "$HOME/.ninja-cli-mcp.env" ]]; then
+if [[ -f "$HOME/.ninja-mcp.env" ]]; then
+    source "$HOME/.ninja-mcp.env"
+elif [[ -f "$HOME/.ninja-cli-mcp.env" ]]; then
+    # Legacy config file name - still supported
     source "$HOME/.ninja-cli-mcp.env"
 fi
 

--- a/scripts/run_server_stdio.sh
+++ b/scripts/run_server_stdio.sh
@@ -8,7 +8,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Load environment variables if .env file exists
-if [ -f "$HOME/.ninja-cli-mcp.env" ]; then
+if [ -f "$HOME/.ninja-mcp.env" ]; then
+    set -a
+    source "$HOME/.ninja-mcp.env"
+    set +a
+elif [ -f "$HOME/.ninja-cli-mcp.env" ]; then
+    # Legacy config file name - still supported
     set -a
     source "$HOME/.ninja-cli-mcp.env"
     set +a


### PR DESCRIPTION
This commit fixes two critical issues preventing installation and daemon operation:

1. **Missing Library File**
   - Created scripts/lib/claude_config.sh with required helper functions
   - Functions: detect_claude_mcp_config(), init_claude_mcp_config(), check_config_migration()
   - Fixes "No such file or directory" errors in install_interactive.sh, install_claude_code_mcp.sh, and update_mcp_config.sh

2. **Config File Path Inconsistency**
   - Unified config file name to ~/.ninja-mcp.env across all scripts
   - Added backward compatibility fallback to ~/.ninja-cli-mcp.env
   - Updated scripts: run_daemon.sh, run_server.sh, run_server_stdio.sh, restart_mcp.sh
   - Updated systemd service file to check both config locations

These changes ensure:
- Interactive installation script works without errors
- Daemon processes correctly load API keys and configuration
- Backward compatibility with existing setups using old config file name

Fixes #<issue-number-if-exists>

## Summary

Describe your changes and motivation. Link related issues.

## Changes
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI/CD
- [ ] Other

## Testing
Explain how you tested your changes.

```bash
# Examples
uv run ruff check src/ tests/
uv run mypy src/
uv run pytest tests/ -v
```

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CHANGELOG updated
- [ ] Ready for review
